### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install gulp-luacheck
 
 ```javascript
 var gulp = require("gulp");
-var luacheck = require("luacheck");
+var luacheck = require("gulp-luacheck");
 var options = {};
 
 


### PR DESCRIPTION
The wrong package was require'd. Since `luacheck` is the module that wraps the executable, this causes some confusion.
